### PR TITLE
AZURE_DNS: Retry pending-operation conflicts

### DIFF
--- a/providers/azuredns/azureDnsProvider.go
+++ b/providers/azuredns/azureDnsProvider.go
@@ -20,6 +20,8 @@ import (
 	"github.com/DNSControl/dnscontrol/v4/pkg/providers"
 )
 
+const azurePendingOperationConflictMessage = "Another operation is pending for requested object"
+
 type azurednsProvider struct {
 	zonesClient    *adns.ZonesClient
 	recordsClient  *adns.RecordSetsClient
@@ -387,17 +389,14 @@ retry:
 	defer cancel()
 	_, err = a.recordsClient.CreateOrUpdate(ctx, *a.resourceGroup, zoneName, recordName, azRecType, *rrset, nil)
 
-	var e *azcore.ResponseError
-	if errors.As(err, &e) {
-		if e.StatusCode == http.StatusTooManyRequests {
-			waitTime = waitTime * 2
-			if waitTime > 300 {
-				return err
-			}
-			printer.Printf("AZURE_DNS: rate-limit paused for %v.\n", waitTime)
-			time.Sleep(time.Duration(waitTime+1) * time.Second)
-			goto retry
+	if retryReason := retryableRecordSetMutation(err); retryReason != "" {
+		waitTime = waitTime * 2
+		if waitTime > 300 {
+			return err
 		}
+		printer.Printf("AZURE_DNS: %s paused for %v.\n", retryReason, waitTime)
+		time.Sleep(time.Duration(waitTime+1) * time.Second)
+		goto retry
 	}
 
 	return err
@@ -421,20 +420,34 @@ retry:
 	defer cancel()
 	_, err = a.recordsClient.Delete(ctx, *a.resourceGroup, zoneName, shortName, azRecType, nil)
 
-	var e *azcore.ResponseError
-	if errors.As(err, &e) {
-		if e.StatusCode == http.StatusTooManyRequests {
-			waitTime = waitTime * 2
-			if waitTime > 300 {
-				return err
-			}
-			printer.Printf("AZURE_DNS: rate-limit paused for %v.\n", waitTime)
-			time.Sleep(time.Duration(waitTime+1) * time.Second)
-			goto retry
+	if retryReason := retryableRecordSetMutation(err); retryReason != "" {
+		waitTime = waitTime * 2
+		if waitTime > 300 {
+			return err
 		}
+		printer.Printf("AZURE_DNS: %s paused for %v.\n", retryReason, waitTime)
+		time.Sleep(time.Duration(waitTime+1) * time.Second)
+		goto retry
 	}
 
 	return err
+}
+
+func retryableRecordSetMutation(err error) string {
+	var e *azcore.ResponseError
+	if !errors.As(err, &e) {
+		return ""
+	}
+
+	if e.StatusCode == http.StatusTooManyRequests {
+		return "rate-limit"
+	}
+
+	if e.StatusCode == http.StatusConflict && e.ErrorCode == "Conflict" && strings.Contains(e.Error(), azurePendingOperationConflictMessage) {
+		return "pending operation"
+	}
+
+	return ""
 }
 
 func nativeToRecordTypeDiff2(recordType *string) (adns.RecordType, error) {

--- a/providers/azuredns/azureDnsProvider_test.go
+++ b/providers/azuredns/azureDnsProvider_test.go
@@ -1,0 +1,71 @@
+package azuredns
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+func TestRetryableRecordSetMutation(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "rate limit",
+			err:  &azcore.ResponseError{StatusCode: http.StatusTooManyRequests, ErrorCode: "TooManyRequests"},
+			want: "rate-limit",
+		},
+		{
+			name: "pending operation conflict",
+			err:  newAzureResponseError(http.StatusConflict, "Conflict", azurePendingOperationConflictMessage),
+			want: "pending operation",
+		},
+		{
+			name: "wrapped pending operation conflict",
+			err:  fmt.Errorf("wrapped: %w", newAzureResponseError(http.StatusConflict, "Conflict", azurePendingOperationConflictMessage)),
+			want: "pending operation",
+		},
+		{
+			name: "other conflict",
+			err:  newAzureResponseError(http.StatusConflict, "Conflict", "The record set already exists."),
+			want: "",
+		},
+		{
+			name: "wrong conflict code",
+			err:  newAzureResponseError(http.StatusConflict, "PreconditionFailed", azurePendingOperationConflictMessage),
+			want: "",
+		},
+		{
+			name: "non Azure error",
+			err:  fmt.Errorf("plain error"),
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := retryableRecordSetMutation(tt.err); got != tt.want {
+				t.Fatalf("retryableRecordSetMutation() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func newAzureResponseError(statusCode int, code string, message string) *azcore.ResponseError {
+	body := fmt.Sprintf(`{"error":{"code":%q,"message":%q}}`, code, message)
+	return &azcore.ResponseError{
+		ErrorCode:  code,
+		StatusCode: statusCode,
+		RawResponse: &http.Response{
+			StatusCode: statusCode,
+			Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+			Body:       io.NopCloser(strings.NewReader(body)),
+		},
+	}
+}

--- a/providers/azureprivatedns/azurePrivateDnsProvider.go
+++ b/providers/azureprivatedns/azurePrivateDnsProvider.go
@@ -3,6 +3,7 @@ package azureprivatedns
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -16,6 +17,8 @@ import (
 	"github.com/DNSControl/dnscontrol/v4/pkg/printer"
 	"github.com/DNSControl/dnscontrol/v4/pkg/providers"
 )
+
+const azurePendingOperationConflictMessage = "Another operation is pending for requested object"
 
 type azurednsProvider struct {
 	zonesClient    *adns.PrivateZonesClient
@@ -288,16 +291,14 @@ retry:
 	defer cancel()
 	_, err = a.recordsClient.CreateOrUpdate(ctx, *a.resourceGroup, zoneName, azRecType, recordName, *rrset, nil)
 
-	if e, ok := err.(*azcore.ResponseError); ok {
-		if e.StatusCode == http.StatusTooManyRequests {
-			waitTime = waitTime * 2
-			if waitTime > 300 {
-				return err
-			}
-			printer.Printf("AZURE_PRIVATE_DNS: rate-limit paused for %v.\n", waitTime)
-			time.Sleep(time.Duration(waitTime+1) * time.Second)
-			goto retry
+	if retryReason := retryableRecordSetMutation(err); retryReason != "" {
+		waitTime = waitTime * 2
+		if waitTime > 300 {
+			return err
 		}
+		printer.Printf("AZURE_PRIVATE_DNS: %s paused for %v.\n", retryReason, waitTime)
+		time.Sleep(time.Duration(waitTime+1) * time.Second)
+		goto retry
 	}
 
 	return err
@@ -321,19 +322,34 @@ retry:
 	defer cancel()
 	_, err = a.recordsClient.Delete(ctx, *a.resourceGroup, zoneName, azRecType, shortName, nil)
 
-	if e, ok := err.(*azcore.ResponseError); ok {
-		if e.StatusCode == http.StatusTooManyRequests {
-			waitTime = waitTime * 2
-			if waitTime > 300 {
-				return err
-			}
-			printer.Printf("AZURE_PRIVATE_DNS: rate-limit paused for %v.\n", waitTime)
-			time.Sleep(time.Duration(waitTime+1) * time.Second)
-			goto retry
+	if retryReason := retryableRecordSetMutation(err); retryReason != "" {
+		waitTime = waitTime * 2
+		if waitTime > 300 {
+			return err
 		}
+		printer.Printf("AZURE_PRIVATE_DNS: %s paused for %v.\n", retryReason, waitTime)
+		time.Sleep(time.Duration(waitTime+1) * time.Second)
+		goto retry
 	}
 
 	return err
+}
+
+func retryableRecordSetMutation(err error) string {
+	var e *azcore.ResponseError
+	if !errors.As(err, &e) {
+		return ""
+	}
+
+	if e.StatusCode == http.StatusTooManyRequests {
+		return "rate-limit"
+	}
+
+	if e.StatusCode == http.StatusConflict && e.ErrorCode == "Conflict" && strings.Contains(e.Error(), azurePendingOperationConflictMessage) {
+		return "pending operation"
+	}
+
+	return ""
 }
 
 func nativeToRecordTypeDiff(recordType *string) (adns.RecordType, error) {

--- a/providers/azureprivatedns/azurePrivateDnsProvider_test.go
+++ b/providers/azureprivatedns/azurePrivateDnsProvider_test.go
@@ -1,0 +1,71 @@
+package azureprivatedns
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+func TestRetryableRecordSetMutation(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "rate limit",
+			err:  &azcore.ResponseError{StatusCode: http.StatusTooManyRequests, ErrorCode: "TooManyRequests"},
+			want: "rate-limit",
+		},
+		{
+			name: "pending operation conflict",
+			err:  newAzureResponseError(http.StatusConflict, "Conflict", azurePendingOperationConflictMessage),
+			want: "pending operation",
+		},
+		{
+			name: "wrapped pending operation conflict",
+			err:  fmt.Errorf("wrapped: %w", newAzureResponseError(http.StatusConflict, "Conflict", azurePendingOperationConflictMessage)),
+			want: "pending operation",
+		},
+		{
+			name: "other conflict",
+			err:  newAzureResponseError(http.StatusConflict, "Conflict", "The record set already exists."),
+			want: "",
+		},
+		{
+			name: "wrong conflict code",
+			err:  newAzureResponseError(http.StatusConflict, "PreconditionFailed", azurePendingOperationConflictMessage),
+			want: "",
+		},
+		{
+			name: "non Azure error",
+			err:  fmt.Errorf("plain error"),
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := retryableRecordSetMutation(tt.err); got != tt.want {
+				t.Fatalf("retryableRecordSetMutation() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func newAzureResponseError(statusCode int, code string, message string) *azcore.ResponseError {
+	body := fmt.Sprintf(`{"error":{"code":%q,"message":%q}}`, code, message)
+	return &azcore.ResponseError{
+		ErrorCode:  code,
+		StatusCode: statusCode,
+		RawResponse: &http.Response{
+			StatusCode: statusCode,
+			Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+			Body:       io.NopCloser(strings.NewReader(body)),
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- retry Azure DNS record-set mutations when Azure reports the transient pending-operation 409 Conflict
- preserve existing 429 retry behavior
- apply the same targeted retry classifier to Azure Private DNS mutations

## Tests
- go test ./providers/azuredns ./providers/azureprivatedns
- go test ./...

Fixes DNSControl/dnscontrol#4363